### PR TITLE
Allow result of wait to be discarded

### DIFF
--- a/Sources/CombineWaiting/Publisher+Wait.swift
+++ b/Sources/CombineWaiting/Publisher+Wait.swift
@@ -6,6 +6,7 @@ public extension Publisher {
     /// Waits for this publisher to complete within the given timeout.
     /// - Parameter timeout: The maximum amount of time to wait for values.
     /// - Returns: The values emitted by this publisher and the status of this publisher.
+    @discardableResult
     func wait(timeout: TimeInterval = 0, executing work: @escaping () -> Void = {}) -> WaitResult<Output, Failure> {
         var values = [Output]()
         var completion: Subscribers.Completion<Failure>?


### PR DESCRIPTION
I like to use `wait` for test setup and in those cases I'm not really interested in the result. I can of course use `_ = repository.save(....).wait()` but by adding `@discardableResult` I can just use `repository.save(....).wait()` which is nicer.